### PR TITLE
Use BCrypt instead of SHA-256 as a password hashing algorithm

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,9 @@
                            [hiccup "0.3.5"]
                            [clj-stacktrace "0.2.2"]
                            [ring-reload-modified "0.1.0"]
-                           [net.java.dev.jets3t/jets3t "0.8.0"]]
+                           [net.java.dev.jets3t/jets3t "0.8.0"]
+                           [org.mindrot/jbcrypt "0.3m"]]
             :dev-dependencies [[marginalia "0.5.1"]
-                               [org.clojars.rayne/autodoc "0.8.0-SNAPSHOT"]]
+                               [org.clojars.rayne/autodoc "0.8.0-SNAPSHOT"]
+                               [swank-clojure "1.2.1"]]
             :main noir.example)

--- a/src/noir/util/crypt.clj
+++ b/src/noir/util/crypt.clj
@@ -1,34 +1,24 @@
 (ns noir.util.crypt
-  "Simple functions for encrypting strings and comparing them. Typically used for storing passwords."
+  "Simple functions for hashing strings and comparing them. Typically used for storing passwords."
   (:refer-clojure :exclude [compare])
   (:require [ring.util.codec :as codec])
-  (:import java.security.MessageDigest java.security.SecureRandom))
+  (:import org.mindrot.jbcrypt.BCrypt))
 
-(defn gen-salt []
-  (let [salt (byte-array 8)]
-    ;; generate a truly random sequence of bytes
-    (.. SecureRandom (getInstance "SHA1PRNG") (nextBytes salt))
-    salt))
+(defn gen-salt
+  "Generate a salt for BCrypt's hashing purposes."
+  ([] (BCrypt/gensalt))
+  ([rounds] (BCrypt/gensalt rounds)))
 
-(defn ext-salt [stored]
-  (byte-array (take 8 (codec/base64-decode stored))))
-
-(defn encrypt 
-  "Encrypt the given string with a generated or supplied salt. Uses SHA-256 encryption."
+(defn gen-hash
+  "Hash the given string with a generated or supplied salt. Uses BCrypt hashing algorithm.
+The given salt (if supplied) needs to be in a format acceptable by Bcrypt. It's recommended 
+that one uses `gen-salt` for generating salts."
   ;; generate a salt
-  ([raw] (encrypt (gen-salt) raw))
+  ([raw] (gen-hash (gen-salt) raw))
   ([salt raw]
-    ;; append the salt to the front
-   (str (codec/base64-encode salt) 
-        (codec/base64-encode (let [mdig (. MessageDigest getInstance "SHA-256")
-                                   raw-bytes (codec/base64-decode raw)]
-                               (. mdig reset)
-                               ;; use the salt to encrypt
-                               (. mdig update salt)
-                               (. mdig digest raw-bytes))))))
+     (BCrypt/hashpw raw salt)))
 
 (defn compare 
-  "Compare a raw string with an already encrypted string"
-  [raw encrypted]
-  (= (encrypt (ext-salt encrypted) raw) encrypted))
-
+  "Compare a raw string with an already hashed string"
+  [raw hashed]
+  (BCrypt/checkpw raw hashed))

--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -4,7 +4,7 @@
   (:require [noir.util.crypt :as crypt]))
 
 (deftest hashing
-         (let [pass (crypt/encrypt "password")]
+         (let [pass (crypt/gen-hash "password")]
            (is (crypt/compare "password" pass)))) 
 
 (run-tests)


### PR DESCRIPTION
Port the password hashing functions to use BCrypt instead of SHA-256 and fix function names, documentation.
- Add jBCrypt as a dependency
- Rename fn `encrypt` to `gen-hash` and fix it to use BCrypt
- Remove unnecessary fns & fix docs
- Fix tests
- Add swank-clojure as a dev dependency for poor Emacs users
