### PR TITLE
allow different session storages

### DIFF
--- a/src/noir/options.clj
+++ b/src/noir/options.clj
@@ -8,8 +8,10 @@
 
 (defn get 
   "Get an option from the noir options map"
-  [k]
-  (clojure.core/get *options* k))
+  ([k default]
+   (clojure.core/get *options* k default))
+  ([k]
+   (clojure.core/get *options* k)))
 
 (defn dev-mode? 
   "Returns if the server is currently in development mode"

--- a/src/noir/session.clj
+++ b/src/noir/session.clj
@@ -36,4 +36,4 @@
 (defn wrap-noir-session [handler]
   (-> handler
     (noir-session)
-    (wrap-session {:store (memory-store mem)})))
+    (wrap-session {:store (options/get :store (memory-store mem))})))


### PR DESCRIPTION
To go past the one machine barrier, using an alternative
storage is mandatory.
