### PR TITLE
Revert to stable release of swank-clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,5 +13,5 @@
                            [org.mindrot/jbcrypt "0.3m"]]
             :dev-dependencies [[marginalia "0.6.0"]
                                [org.clojars.rayne/autodoc "0.8.0-SNAPSHOT"]
-                               [swank-clojure "1.4.0-SNAPSHOT"]]
+                               [swank-clojure "1.3.1"]]
             :autodoc {:name "Noir" :page-title "Noir Docs" :load-except-list [#"noir\/content.*"]})


### PR DESCRIPTION
Sorry to make a second edit here, but at least for my setup the latest snapshot of swank-clojure is broken. Probably not the best idea to depend on SNAPSHOTs when good stable releases are available anyway.
