### PR TITLE
Store session vars and cookies as strings. Functions for cookie signing.

### DIFF
--- a/src/noir/cookies.clj
+++ b/src/noir/cookies.clj
@@ -1,8 +1,7 @@
 (ns noir.cookies
   "Stateful access to cookie values"
   (:refer-clojure :exclude [get remove])
-  (:require [clojure.contrib.logging :as lg]
-            [noir.util.crypt :as crypt])
+  (:require [noir.util.crypt :as crypt])
   (:use ring.middleware.cookies))
 
 (def *cur-cookies* nil)

--- a/src/noir/cookies.clj
+++ b/src/noir/cookies.clj
@@ -35,7 +35,7 @@
 (defn put-signed!
   "Adds a new cookie whose name is k and has the value v. In addition,
   adds another cookie that checks the authenticity of 'v'. Sign-key
-  should be a secret that's ideally site-wide, ideally user or session wide."
+  should be a secret that's user-wide, session-wide or site wide (worst)."
   [sign-key k v]
   (let [actual-v (if (map? v) (:value v) v)]
     (put! k v) 

--- a/src/noir/cookies.clj
+++ b/src/noir/cookies.clj
@@ -1,6 +1,8 @@
 (ns noir.cookies
   "Stateful access to cookie values"
   (:refer-clojure :exclude [get remove])
+  (:require [clojure.contrib.logging :as lg]
+            [noir.util.crypt :as crypt])
   (:use ring.middleware.cookies))
 
 (def *cur-cookies* nil)
@@ -9,21 +11,50 @@
 (defn put! 
   "Add a new cookie whose name is k and has the value v. If v is a string
   a cookie map is created with :path '/'. To set custom attributes, such as
-  \"expires\", provide a map as v."
+  \"expires\", provide a map as v. Stores all keys as strings."
   [k v]
   (let [props (if (map? v)
                 v
                 {:value v :path "/"})]
-    (swap! *new-cookies* assoc k props)))
+    (swap! *new-cookies* assoc (name k) props)))
 
 (defn get
-  "Get the value of a cookie from the request. k can either be a string or keyword"
+  "Get the value of a cookie from the request. k can either be a string or keyword.
+   If this is a signed cookie, use get-signed, otherwise the signature will not be
+   checked."
   ([k] (get k nil))
   ([k default] 
    (let [str-k (name k)]
      (if-let [v (get-in *cur-cookies* [str-k :value])]
        v
        default))))
+
+(defn signed-name [k]
+  "Construct the name of the signing cookie using a simple suffix."
+  (str (name k) "__s"))
+
+(defn put-signed!
+  "Adds a new cookie whose name is k and has the value v. In addition,
+  adds another cookie that checks the authenticity of 'v'. Sign-key
+  should be a secret that's ideally site-wide, ideally user or session wide."
+  [sign-key k v]
+  (let [actual-v (if (map? v) (:value v) v)]
+    (put! k v) ;;!! DONT CHECK IN.
+    (put! (signed-name k) (crypt/sha1-sign-hex sign-key v))))
+
+(defn get-signed
+  "Get the value of a cookie from the request using 'get'. Verifies that a signing
+   cookie also exists. If not, returns default or nil. "
+  ([sign-key k] (get-signed sign-key k nil))
+  ([sign-key k default]
+     (let [v (get k)
+           stored-sig (get (signed-name k)) ]
+       (println (str v " " (signed-name k) " >" stored-sig))
+       (if (or (lg/spy (nil? stored-sig)) ;; If signature not available,
+               (nil? v) ;; or value is not found,
+               (lg/spy (not= (crypt/sha1-sign-hex sign-key v) stored-sig))) ;; or sig mismatch,
+         default ;; return default.
+         v)))) ;; otherwise return the value.
 
 (defn noir-cookies [handler]
   (fn [request]

--- a/src/noir/session.clj
+++ b/src/noir/session.clj
@@ -52,7 +52,14 @@
       (when-let [resp (handler request)]
         (assoc resp :session @*noir-session*)))))
 
+(defn assoc-if [m k v]
+  (if (not (nil? v))
+    (assoc m k v)
+    m))
+
 (defn wrap-noir-session [handler]
   (-> handler
     (noir-session)
-    (wrap-session {:store (options/get :session-store (memory-store mem))})))
+    (wrap-session
+     (assoc-if {:store (options/get :session-store (memory-store mem))}
+               :cookie-attrs (options/get :session-cookie-attrs)))))

--- a/src/noir/session.clj
+++ b/src/noir/session.clj
@@ -1,6 +1,7 @@
 (ns noir.session
-  "Stateful session handling functions. Uses a memory-store by default, but can use a custom store 
-  by supplying a :session-store option to server/start."
+  "Stateful session handling functions. Uses a memory-store by
+  default, but can use a custom store by supplying a :session-store
+  option to server/start. All keys are stored as strings."
   (:refer-clojure :exclude [get remove])
   (:use ring.middleware.session
         ring.middleware.session.memory)
@@ -12,13 +13,13 @@
 (defn put! 
   "Associates the key with the given value in the session"
   [k v]
-  (swap! *noir-session* assoc k v))
+  (swap! *noir-session* assoc (name k) v))
 
 (defn get 
   "Get the key's value from the session, returns nil if it doesn't exist."
   ([k] (get k nil))
   ([k default]
-    (clojure.core/get @*noir-session* k default)))
+    (clojure.core/get @*noir-session* (name k) default)))
 
 (defn clear! 
   "Remove all data from the session and start over cleanly."
@@ -28,7 +29,7 @@
 (defn remove!
   "Remove a key from the session"
   [k]
-  (swap! *noir-session* dissoc k))
+  (swap! *noir-session* dissoc (name k)))
 
 (defn flash-put!
   "Store a value with a lifetime of one retrieval (on the first flash-get,

--- a/src/noir/util/crypt.clj
+++ b/src/noir/util/crypt.clj
@@ -19,3 +19,11 @@
   "Compare a raw string with an already encrypted string"
   [raw encrypted]
   (BCrypt/checkpw raw encrypted))
+
+(defn sha1-sign-hex [sign-key v]
+  "Using a signing key, compute the sha1 hmac of v and convert to hex."
+  (let [mac (javax.crypto.Mac/getInstance "HmacSHA1")
+        secret (javax.crypto.spec.SecretKeySpec. (.getBytes sign-key), "HmacSHA1")]
+    (.init mac secret)
+    (apply str (map (partial format "%02x") (.doFinal mac (.getBytes v))))))
+

--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -24,25 +24,21 @@
            (is (nil? (cookies/get :noir)))
            (is (= "noir" (cookies/get :noir "noir")))))
 
-(defpage "/cookie-set" {:keys [name value]}
-  (cookies/put-signed! name :noir value)
-  (str "Hello " nme))
-
 (deftest cookies-get-signed
          (with-noir
            (is (nil? (cookies/get :noir)))
-           (println (str @cookies/*new-cookies*))
-           ;; Swap cookies.
-           (swap! cookies/*cur-cookies* merge @cookies/*new-cookies*)
-           ;; Check default behavior for bad keys.
-           (is (nil? (cookies/get-signed "b4d-k3y" :noir)))
-           (is (= "noir" (cookies/get-signed "b4d-k3y" :noir "noir")))
-           ;; Check retrieval of good value.
-           (is (= "stored-value" (cookies/get-signed "s3cr3t-k3y" :noir)))
+           (cookies/put-signed! "s3cr3t-k3y" :noir "stored-value")
+           ;; Use new cookies as cur.
+           (binding [cookies/*cur-cookies* @cookies/*new-cookies*]
+             ;; Check default behavior for bad keys.
+             (is (nil? (cookies/get-signed "b4d-k3y" :noir)))
+             (is (= "noir" (cookies/get-signed "b4d-k3y" :noir "noir")))
+             ;; Check retrieval of good value.
+             (is (= "stored-value" (cookies/get-signed "s3cr3t-k3y" :noir))))
            ;; Modify value,
-           (assoc cookies/*cur-cookies* :noir "changed-value")
-           ;; Check that it's not returned.
-           (is (= "noir" (cookies/get-signed "b4d-k3y" :noir "noir")))))
+           (binding [cookies/*cur-cookies* (assoc @cookies/*new-cookies* "noir" "changed-value")]
+             ;; Check that it's not returned.
+             (is (nil? (cookies/get-signed "s3cr3t-k3y" :noir))))))
 
 (deftest options-get-default
          (with-noir

--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -24,6 +24,26 @@
            (is (nil? (cookies/get :noir)))
            (is (= "noir" (cookies/get :noir "noir")))))
 
+(defpage "/cookie-set" {:keys [name value]}
+  (cookies/put-signed! name :noir value)
+  (str "Hello " nme))
+
+(deftest cookies-get-signed
+         (with-noir
+           (is (nil? (cookies/get :noir)))
+           (println (str @cookies/*new-cookies*))
+           ;; Swap cookies.
+           (swap! cookies/*cur-cookies* merge @cookies/*new-cookies*)
+           ;; Check default behavior for bad keys.
+           (is (nil? (cookies/get-signed "b4d-k3y" :noir)))
+           (is (= "noir" (cookies/get-signed "b4d-k3y" :noir "noir")))
+           ;; Check retrieval of good value.
+           (is (= "stored-value" (cookies/get-signed "s3cr3t-k3y" :noir)))
+           ;; Modify value,
+           (assoc cookies/*cur-cookies* :noir "changed-value")
+           ;; Check that it's not returned.
+           (is (= "noir" (cookies/get-signed "b4d-k3y" :noir "noir")))))
+
 (deftest options-get-default
          (with-noir
            (is (nil? (options/get :noir)))


### PR DESCRIPTION
Provide put-signed! and get-signed functions. These functions require a secret signing key, which is managed outside the scope of these functions (this allows the user to set them based on the site, the user, or the session). Cookie signatures are stored in another cookie. Signed cookies are able to be retrieved with normal (cookie/get), but their signature won't be checked. This is a little bit dangerous in that someone could forget to call that, but allows compatibility with cookies that need to have a certain name. 
