### PR TITLE
Random custom middleware invocation order

### DIFF
--- a/src/noir/server.clj
+++ b/src/noir/server.clj
@@ -18,7 +18,7 @@
             [noir.session :as session]
             [noir.validation :as validation]))
 
-(defonce *middleware* (atom #{}))
+(defonce *middleware* (ref []))
 
 (defn- wrap-route-updating [handler]
   (if (options/dev-mode?)
@@ -76,7 +76,10 @@
   function, which will be passed the handler. Any extra args to be applied should be
   supplied along with the function."
   [func & args]
-  (swap! *middleware* conj [func args]))
+  (dosync 
+    (let [mw [func args]]
+      (if-not (some #(= % mw) @*middleware*)
+        (alter *middleware* conj mw)))))
 
 (defn start 
   "Create a noir server bound to the specified port with a map of options and return it. 


### PR DESCRIPTION
A set-typed _middleware_ makes the order of custom middleware invocation unpredictable. This causes problems when one middleware sets data for another, like with authentication/authorization. The proposed change preserves the call order yet assures that custom middlewares are unique (although I don't think it is important).
