### PR TITLE
Improve s3 util

### DIFF
--- a/src/noir/util/s3.clj
+++ b/src/noir/util/s3.clj
@@ -18,7 +18,7 @@
   "Given a server-spec which contains {:secret-key :access-key} execute the given body
   within the context of an S3 connection"
   [server-spec & body]
-  (binding [*s3* (service server-spec)]
+  `(binding [*s3* (service ~server-spec)]
     ~@body))
 
 (defn put! 

--- a/src/noir/util/s3.clj
+++ b/src/noir/util/s3.clj
@@ -28,6 +28,13 @@
     (. obj setAcl (. AccessControlList REST_CANNED_PUBLIC_READ))
     (. *s3* putObject bucket obj)))
 
+(defn rename!
+  "Rename the given file on S3"
+  [bucket file new-file]
+  (let [new-obj (new S3Object new-file)]
+    (. new-obj setAcl (. AccessControlList REST_CANNED_PUBLIC_READ))
+    (. *s3* renameObject bucket file new-obj)))
+
 (defn list 
   "List all files in the bucket with the given prefix"
   [bucket prefix]


### PR DESCRIPTION
- The `with-s3` macro was throwing a `java.lang.IllegalStateException` with message "Var clojure.core/unquote-splicing is unbound.", this should fix it.
- I have added a `rename!` function to rename files on s3.
