### PR TITLE
Flash

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                            [compojure "1.0.0-RC2"]
                            [org.clojure/tools.namespace "0.1.0"]
                            [clj-json "0.4.3"]
-                           [ring "1.0.0"]
+                           [ring "1.0.1"]
                            [hiccup "0.3.7"]
                            [clj-stacktrace "0.2.3"]
                            [ring-reload-modified "0.1.1"]

--- a/src/noir/cookies.clj
+++ b/src/noir/cookies.clj
@@ -63,7 +63,7 @@
   (fn [request]
     (binding [*cur-cookies* (:cookies request)
               *new-cookies* (atom {})]
-      (let [final (handler request)]
+      (when-let [final (handler request)]
         (assoc final :cookies (merge (:cookies final) @*new-cookies*))))))
 
 (defn wrap-noir-cookies [handler]

--- a/src/noir/server.clj
+++ b/src/noir/server.clj
@@ -51,7 +51,7 @@
   :base-url - the root url to prepend to generated links and resources 
   :resource-root - an alternative name for the public folder
   :session-store - an alternate store for session handling
-  :cookie-attrs - custom session cookie attributes"
+  :session-cookie-attrs - custom session cookie attributes"
   [port & [opts]]
   (println "Starting server...")
   (let [jetty-opts (merge {:port port :join? false} (:jetty-options opts))


### PR DESCRIPTION
We can use this pull request as a way to discuss issues and such. This is _not_ ready to be pulled and is totally broken. I just think pull requests are better than emails for these kinds of things.

So, this is my WIP on the new flash functionality. When I use it, every request results in two wrap-noir-flash triggers. So, even with this `routes` stuff in `wrap-spec-routes`, it still triggers the flash middleware when the browser asks for the favicon. I'm guessing that's because all of the middleware still has to execute before the spec middleware gets a chance to have its stuff injected, which makes it all kind of a moot point.

The way all of this works is really confusing the hell out of me, so I'm sure this is all due to my inability to understand how routes and middleware function at 2AM. I might be able to figure it out tomorrow, but I thought I'd throw this here in case there are some simple things that I'm missing that might be obvious to you.

(Created this new pull request because I accidentally pointed the other one at master.)
