### PR TITLE
Cheshire

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject noir "1.3.0-alpha1"
+(defproject noir "1.3.0-alpha2"
             :description "Noir - a clojure web framework"
             :dependencies [[org.clojure/clojure "1.3.0"]
                            [compojure "1.0.0-RC2"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
             :dependencies [[org.clojure/clojure "1.3.0"]
                            [compojure "1.0.0-RC2"]
                            [org.clojure/tools.namespace "0.1.0"]
-                           [clj-json "0.4.3"]
+                           [cheshire "2.0.4"]
                            [ring "1.0.1"]
                            [hiccup "0.3.7"]
                            [clj-stacktrace "0.2.3"]

--- a/src/noir/response.clj
+++ b/src/noir/response.clj
@@ -1,7 +1,7 @@
 (ns noir.response
   "Simple response helpers to change the content type, redirect, or return a canned response"
   (:refer-clojure :exclude [empty])
-  (:require [clj-json.core :as json]
+  (:require [cheshire.core :as json]
             [noir.options :as options]))
 
 (defn xml 


### PR DESCRIPTION
I propose we switch to cheshire for a couple of recently discovered reasons:
- Cheshire is more actively maintained.
- I have had numerous excellent experiences with the developer of it on his other project, clj-http, and he is the kind of guy that drops everything to fix a bug if it is holding you up.
- Cheshire is totally 100% compatible with Clojure 1.3 while clj-json has at least one var that I know of that isn't declared dynamic and thus results in a warning and could, at any time, result in an explosion. Using cheshire is easier than patching clj-json.
- Cheshire uses the same Java library on the backend as clj-json and thus is just as (or almost as) fast as clj-json.
- Cheshire uses up-to-date versions of jackson. clj-json does not and I have experienced version mismatch issues when using Noir with a project that depends on a project that uses cheshire.
- Cheshire was invented out of the author's need for more features than clj-json provides. It's goal is to provide more features while being just as fast. We may not need those features now, but when we do, they'll be there.
- The change is insignificant because the interface is exactly the same for generating json. The only change is the dependency and the namespace we import.
- Clients of noir should not notice the difference. If they do, so what, this is a 1.3 release that already has breaking changes.
- Because I said so.

What do you think? I think cheshire is a better option here and is more future-proof.
