### PR TITLE
Use hiccup's middleware so that the context path, if present, is used.

### DIFF
--- a/src/noir/server/handler.clj
+++ b/src/noir/server/handler.clj
@@ -4,7 +4,7 @@
         ring.middleware.reload-modified)
   (:import java.net.URLDecoder)
   (:require [compojure.route :as c-route]
-            [hiccup.core :as hiccup]
+            [hiccup.middleware :as hiccup]
             [noir.core :as noir]
             [noir.content.defaults :as defaults]
             [noir.cookies :as cookie]
@@ -25,12 +25,6 @@
   (if (options/dev-mode?)
     (wrap-reload-modified handler ["src"])
     handler))
-
-(defn- wrap-base-url [handler]
-  (let [url (options/get :base-url)]
-    (fn [req]
-      (binding [hiccup/*base-url* url]
-        (handler req)))))
 
 (defn- wrap-custom-middleware [handler]
   (reduce (fn [cur [func args]] (apply func cur args))
@@ -63,7 +57,7 @@
   (binding [options/*options* (options/compile-options opts)]
     (->
       handler
-      (wrap-base-url)
+      (hiccup/wrap-base-url (options/get :base-url))
       (session/wrap-noir-session)
       (cookie/wrap-noir-cookies)
       (validation/wrap-noir-validation)


### PR DESCRIPTION
This allows me to deploy a noir app to a context path on immutant where it lies on disk, without having to package it in a war file. Thanks!
