### PR TITLE
Update hiccup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject noir "1.3.0-beta2"
+(defproject noir "1.3.0-beta3"
   :description "Noir - a clojure web framework"
   :url "http://webnoir.org"
   :codox {:exclude [noir.exception noir.content.defaults
@@ -8,6 +8,6 @@
                  [org.clojure/tools.namespace "0.1.0"]
                  [cheshire "3.0.0"]
                  [ring "1.0.2"]
-                 [hiccup "1.0.0-beta1"]
+                 [hiccup "1.0.0-RC1"]
                  [clj-stacktrace "0.2.4"]
                  [org.mindrot/jbcrypt "0.3m"]])


### PR DESCRIPTION
Hiccup is at version `1.0.0-RC1` now. 

It feels a bit dirty that noir depends on a specific view library at all. Could the explicit hiccup dependency be removed?
