### PR TITLE
Add Clojure response type

### DIFF
--- a/src/noir/response.clj
+++ b/src/noir/response.clj
@@ -58,3 +58,11 @@
   []
   {:status 200
    :body ""})
+
+(defn clojure
+  "Wraps the response in the `application/clojure` content-type
+   and calls pr-str on the Clojure data stuctures passed in."
+  [data]
+  (response/content-type
+   "application/clojure; charset=utf-8"
+   (pr-str data)))


### PR DESCRIPTION
I'm not sure if you'd want this in Noir, but I wrote this for refheap so I could properly return Clojure data structures from the API.

One thing I'm not sure about is whether or not `application/clojure` would be 'correct'. There is no standard for it, so I guess we can pick whatever we want. I'm not sure what I'd use beyond that.

Anyways, just throwing it out there. No skin off my back if it doesn't belong in Noir. :D
