### PR TITLE
Docstring-able defpartial

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,5 @@
                  [ring "1.0.2"]
                  [hiccup "1.0.0-beta1"]
                  [clj-stacktrace "0.2.4"]
-                 [org.mindrot/jbcrypt "0.3m"]])
+                 [org.mindrot/jbcrypt "0.3m"]
+                 [org.clojure/tools.macro "0.1.1"]])

--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -2,7 +2,8 @@
   "Functions to work with partials and pages."
   (:use hiccup.core
         compojure.core)
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [clojure.tools.macro :as macro]))
 
 (defonce noir-routes (atom {}))
 (defonce route-funcs (atom {}))
@@ -100,11 +101,13 @@
        (swap! noir-routes assoc ~(keyword fn-name) (~action ~url {params# :params} (~fn-name params#))))))
 
 (defmacro defpartial
-  "Create a function that returns html using hiccup. The function is callable with the given name."
-  [fname params & body]
-  `(defn ~fname ~params
-     (html
-       ~@body)))
+  "Create a function that returns html using hiccup. The function is callable with the given name. Can optionally include a docstring or metadata map, like a normal function declaration."
+  [fname & args]
+  (let [[fname params] (macro/name-with-attributes fname args)
+        body (rest (filter vector? args))]
+    `(defn ~fname ~@params
+       (html
+        ~@body))))
 
 (defn ^{:skip-wiki true} route-arguments
   "returns the list of route arguments in a route"

--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -104,8 +104,7 @@
   "Create a function that returns html using hiccup. The function is callable with the given name. Can optionally include a docstring or metadata map, like a normal function declaration."
   [fname & args]
   (let [[fname args] (macro/name-with-attributes fname args)
-        params (first args)
-        body (rest args)]
+        [params & body] args]
     `(defn ~fname ~params
        (html
         ~@body))))

--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -103,10 +103,10 @@
 (defmacro defpartial
   "Create a function that returns html using hiccup. The function is callable with the given name. Can optionally include a docstring or metadata map, like a normal function declaration."
   [fname & args]
-  (let [[fname params] (macro/name-with-attributes fname args)
-        body (if-let [fv (first (filter vector? args))]
-               (second (split-at (inc (.indexOf args fv)) args)))]
-    `(defn ~fname ~@params
+  (let [[fname args] (macro/name-with-attributes fname args)
+        params (first args)
+        body (rest args)]
+    `(defn ~fname ~params
        (html
         ~@body))))
 

--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -104,7 +104,8 @@
   "Create a function that returns html using hiccup. The function is callable with the given name. Can optionally include a docstring or metadata map, like a normal function declaration."
   [fname & args]
   (let [[fname params] (macro/name-with-attributes fname args)
-        body (rest (filter vector? args))]
+        body (if-let [fv (first (filter vector? args))]
+               (second (split-at (inc (.indexOf args fv)) args)))]
     `(defn ~fname ~@params
        (html
         ~@body))))


### PR DESCRIPTION
I found myself wanting to be able to document certain template functions; this patch uses clojure.tools.macro/name-with-attributes to parse and associate optional docstrings/metadata.
