### PR TITLE
Remove duplicate wrap-custom-middleware

### DIFF
--- a/src/noir/server/handler.clj
+++ b/src/noir/server/handler.clj
@@ -120,7 +120,6 @@
   [handler opts]
   (routes handler
           (-> (apply routes (spec-routes))
-              (wrap-custom-middleware)
               (cookie/wrap-noir-cookies)
               (validation/wrap-noir-validation)
               (hiccup/wrap-base-url (options/get :base-url))


### PR DESCRIPTION
An extra wrap-custom-middleware was causing middlewares to get wrapped twice, and thus be executed 2 (or 3) times per each request. This was a problem because I was trying to write  a middleware which has side-effects, and getting called multiple times per requests is not OK.

Traceback of a middleware at its execution,  was:

``` text
** 1st time:

             handler.clj:67 noir.server.handler/wrap-custom-middleware
             handler.clj:95 noir.server.handler/init-routes
            handler.clj:136 noir.server.handler/base-handler
            RestFn.java:408 clojure.lang.RestFn.invoke
              server.clj:16 noir.server/gen-handler

** 2nd time:
                handler.clj:65 noir.server.handler/wrap-custom-middleware[fn]
            ArrayChunk.java:58 clojure.lang.ArrayChunk.reduce
              protocols.clj:30 clojure.core.protocols/fn
              protocols.clj:11 clojure.core.protocols/fn[fn]
                 core.clj:5995 clojure.core/reduce
                handler.clj:67 noir.server.handler/wrap-custom-middleware
               handler.clj:124 noir.server.handler/wrap-spec-routes
                 server.clj:16 noir.server/gen-handler
```

This patch deletes the second wrap-custom-middleware. After applying this patch, middleware gets wrapped exactly once.
