### PR TITLE
Add print-state function, and make example code in custom-handler* docstring compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pom.xml
+/target/
 *jar
 /lib/
 /classes/

--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -212,7 +212,7 @@
   a compojure route using noir's [:method route] syntax, but allows functions
   to be created dynamically:
 
-  (custom-handler* [:post \"/login\"] (fn [params] (println req)))
+  (custom-handler* [:post \"/login\"] (fn [params] (println params)))
 
   These are primarily used to interface with other dynamic handler generating libraries"
   [route func]

--- a/src/noir/util/test.clj
+++ b/src/noir/util/test.clj
@@ -62,23 +62,33 @@
 
 (defn print-state
   "Print the state of the noir server's routes/middleware/wrappers.
-   If optional details? arg is truthy, show noir-routes and route-funcs too."
+   If optional details? arg is truthy, show noir-routes, route-funcs,
+   and status pages too."
   [& details?]
-  (let [print-func (if details? pprint (comp pprint sort keys))]
-  (println "== Pre-Routes ==")
-  (print-func @noir.core/pre-routes)
+  (let [print-func (if details? pprint (comp println pprint sort keys))]
+    
+    (println "== Pre-Routes ==")
+    (print-func @noir.core/pre-routes)
   
-  (println "== Routes and Funcs ==")
-  (print-func (merge-with vector @noir.core/noir-routes  @noir.core/route-funcs))
+    (println "== Routes and Funcs ==")
+    (print-func (merge-with vector @noir.core/noir-routes  @noir.core/route-funcs))
   
-  (println "== Post-Routes ==")
-  (pprint @noir.core/post-routes)
+    (println "== Post-Routes ==")
+    (pprint @noir.core/post-routes)
   
-  (println "== Compojure-Routes ==")
-  (pprint @noir.core/compojure-routes)
+    (println "== Compojure-Routes ==")
+    (pprint @noir.core/compojure-routes)
   
-  (println "== Middleware ==")
-  (pprint @noir.server.handler/middleware)
+    (println "== Middleware ==")
+    (pprint @noir.server.handler/middleware)
   
-  (println "== Wrappers ==")
-  (pprint @noir.server.handler/wrappers)))
+    (println "== Wrappers ==")
+    (pprint @noir.server.handler/wrappers)
+
+    (println "== Memory Store ==")
+    (pprint @noir.session/mem)
+  
+    (when details?
+      (do (println "== Status Pages ==")
+          (pprint @noir.statuses/status-pages)))))
+    

--- a/src/noir/util/test.clj
+++ b/src/noir/util/test.clj
@@ -1,6 +1,7 @@
 (ns noir.util.test
   "A set of utilities for testing a Noir project"
-  (:use clojure.test)
+  (:use clojure.test
+        [clojure.pprint :only [pprint]])
   (:require [noir.server :as server]
             [noir.session :as session]
             [noir.validation :as vali]
@@ -57,3 +58,27 @@
   [ring-req]
   (let [handler (server/gen-handler options/*options*)]
     (handler ring-req)))
+
+
+(defn print-state
+  "Print the state of the noir server's routes/middleware/wrappers.
+   If optional details? arg is truthy, show noir-routes and route-funcs too."
+  [& details?]
+  (let [print-func (if details? pprint (comp pprint sort keys))]
+  (println "== Pre-$outes ==")
+  (print-func @noir.core/pre-routes)
+  
+  (println "== Routes  and Funcs ==")
+  (print-func (merge-with vector @noir.core/noir-routes  @noir.core/route-funcs))
+  
+  (println "== Post-Routes ==")
+  (pprint @noir.core/post-routes)
+  
+  (println "== Compojure-Routes ==")
+  (pprint @noir.core/compojure-routes)
+  
+  (println "== Middleware ==")
+  (pprint @noir.server.handler/middleware)
+  
+  (println "== Wrappers ==")
+  (pprint @noir.server.handler/wrappers)))

--- a/src/noir/util/test.clj
+++ b/src/noir/util/test.clj
@@ -65,10 +65,10 @@
    If optional details? arg is truthy, show noir-routes and route-funcs too."
   [& details?]
   (let [print-func (if details? pprint (comp pprint sort keys))]
-  (println "== Pre-$outes ==")
+  (println "== Pre-Routes ==")
   (print-func @noir.core/pre-routes)
   
-  (println "== Routes  and Funcs ==")
+  (println "== Routes and Funcs ==")
   (print-func (merge-with vector @noir.core/noir-routes  @noir.core/route-funcs))
   
   (println "== Post-Routes ==")

--- a/src/noir/validation.clj
+++ b/src/noir/validation.clj
@@ -43,8 +43,9 @@
 (defn valid-file?
   "Returns true if a valid file was supplied"
   [m]
-  (and (> (:size m) 0)
-       (:filename m)))
+  (and (:size m)
+   (> (:size m) 0)
+   (:filename m)))
 
 
 (defn valid-number?

--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -331,7 +331,24 @@
                             ((session/noir-session
                               #(assoc % :session (dissoc (:session %) :foo)))
                              base-map))
-                           :foo))))))
+                           :foo))))
+    ;; dissocing one key doesn't affect any others
+    (let [base-map (assoc base-map :session {:foo "bar" :quuz "auugh"})
+          part-dissoc (:session
+                       ((session/noir-session
+                         #(assoc % :session (dissoc (:session %) :foo)))
+                        base-map))]
+      (is (not (contains? part-dissoc :foo)))
+      (is (= "auugh" (:quuz  part-dissoc)))
+      ;; changing one key doesn't affect any others
+      (let [part-change (:session
+                         ((session/noir-session
+                           #(assoc-in % [:session :foo] "baz"))
+                          base-map))]
+        (is (= "baz" (:foo part-change)))
+        (is (= "auugh" (:quuz  part-change)))))))
+
+
       
 
 


### PR DESCRIPTION
Add a print-state function to show state of routes and middleware.

Also, fix example code given in the docstring for custom-handler\* so that it compiles.
