### PR TITLE
make example code compile

### DIFF
--- a/src/noir/core.clj
+++ b/src/noir/core.clj
@@ -212,7 +212,7 @@
   a compojure route using noir's [:method route] syntax, but allows functions
   to be created dynamically:
 
-  (custom-handler* [:post \"/login\"] (fn [params] (println req)))
+  (custom-handler* [:post \"/login\"] (fn [params] (println params)))
 
   These are primarily used to interface with other dynamic handler generating libraries"
   [route func]


### PR DESCRIPTION
A minor fix to docstring in compojure-route.
