### PR TITLE
If the form was sent without multipart-binary, there will be no :size key

### DIFF
--- a/src/noir/validation.clj
+++ b/src/noir/validation.clj
@@ -43,7 +43,8 @@
 (defn valid-file?
   "Returns true if a valid file was supplied"
   [m]
-  (and (> (:size m) 0)
+  (and (:size m)
+       (> (:size m) 0)
        (:filename m)))
 
 


### PR DESCRIPTION
 Handle this gracefully and invalidate the field without throwing an exception.
