### PR TITLE
Update src/noir/server/handler.clj

### DIFF
--- a/src/noir/server/handler.clj
+++ b/src/noir/server/handler.clj
@@ -57,7 +57,7 @@
 
 (defn- wrap-route-updating [handler]
   (if (options/dev-mode?)
-    (wrap-reload handler ["src"])
+    (wrap-reload handler {:dirs ["src"]})
     handler))
 
 (defn- wrap-custom-middleware [handler]


### PR DESCRIPTION
This currently only works by accident, because wrap-reload's default
is the same. :)
Recent versions of ring-devel have changed the signature to expect an 
options map with a :dirs key.
