### PR TITLE
Adding routing to allow base-url to work with standalone app

### DIFF
--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -227,6 +227,12 @@
         (has-status 200)
         (has-body "<a href=\"/woohoo/hey\">link</a>"))))
 
+(deftest base-url-routing
+  (binding [options/*options* {:base-url "/woohoo"}]
+    (-> (send-request "/woohoo/base-url")
+        (has-status 200)
+        (has-body "<a href=\"/woohoo/hey\">link</a>"))))
+
 (deftest jsonp
   (-> (resp/jsonp "jsonp245" {:pinot "noir"})
       (has-content-type "application/json; charset=utf-8")


### PR DESCRIPTION
Hi,

I saw [this discussion](http://grokbase.com/t/gg/clj-noir/123t4xgndd/noir-defpage-and-compojures-context-macro) today and made this change based on what was discussed. It is the default behaviour, so the result is that /my-page and /my-context/my-page work when base-url is specified.

It will not override the context set by the container so should not affect those already running inside Tomcat or Jetty but I haven't tested this so you may want to check before releasing.

Thanks
